### PR TITLE
fix: attach library component to Maven publication

### DIFF
--- a/crashreporter/build.gradle
+++ b/crashreporter/build.gradle
@@ -36,6 +36,11 @@ android {
 
     namespace("com.balsikandar.crashreporter")
 
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+        }
+    }
 }
 
 apply from: '../compile_options.gradle'

--- a/crashreporter/upload_maven.gradle
+++ b/crashreporter/upload_maven.gradle
@@ -2,19 +2,14 @@ apply plugin: 'maven-publish'
 
 def group_name = "com.balsikandar.android"
 def module_name = "crashreporter"
-def lib_version = '1.3.0'
+def lib_version = '1.4.2'
 
 afterEvaluate {
     publishing {
         publications {
             release(MavenPublication) {
-                groupId group_name
+                from components.release
 
-                artifactId module_name
-                version lib_version
-            }
-
-            debug(MavenPublication) {
                 groupId group_name
 
                 artifactId module_name


### PR DESCRIPTION
## Problem

Publishing via `:crashreporter:publishReleasePublicationToGitHubPackagesRepository` uploaded only a bare POM — the AAR (and dependency metadata) never made it to GitHub Packages.

## Root cause

The `MavenPublication` blocks in `upload_maven.gradle` set the Maven coordinates but never attached the library component (`from components.release`), so the publication had no artifacts and an empty dependency list.

## Changes

- Add `from components.release` to the release publication so the AAR, sources jar, Gradle module metadata and POM dependencies are published
- Add `android.publishing.singleVariant("release") { withSourcesJar() }` to `crashreporter/build.gradle` — required on AGP 8.x for `components.release` to exist
- Remove the `debug` publication: it used the exact same `groupId:artifactId:version` as the release publication, so the two would clobber each other (GitHub Packages rejects duplicate versions with HTTP 409)
- Bump `lib_version` to 1.4.2

## Verification

Ran `:crashreporter:publishReleasePublicationToMavenLocal`; the publication now contains:

- `crashreporter.aar` including `classes.jar`, `jni/arm64-v8a/libbreakpad-core.so` (16 KB aligned) and `jni/armeabi-v7a/libbreakpad-core.so`
- `-sources.jar`
- POM with the 7 library dependencies (previously none)
- Gradle module metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release builds are now prepared for publishing with source code included, making published artifacts more complete for consumers.
  * Maven publishing has been updated to use a newer release, improving the publishing workflow and artifact generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->