### PR TITLE
feat: pluggable crash report upload with state tracking

### DIFF
--- a/crashreporter/build.gradle
+++ b/crashreporter/build.gradle
@@ -34,6 +34,12 @@ android {
         }
     }
 
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
+
     namespace("com.balsikandar.crashreporter")
 
     publishing {
@@ -57,8 +63,18 @@ dependencies {
 
     implementation 'androidx.recyclerview:recyclerview:1.4.0'
     implementation 'com.google.android.material:material:1.12.0'
+
+    // Crash-report upload state tracking + background upload
+    implementation 'androidx.room:room-runtime:2.6.1'
+    kapt 'androidx.room:room-compiler:2.6.1'
+    implementation 'androidx.work:work-runtime:2.9.1'
+
     testImplementation 'junit:junit:4.13.2'
     implementation 'androidx.test.ext:junit:1.1.5'
+    testImplementation 'androidx.room:room-testing:2.6.1'
+    testImplementation 'org.robolectric:robolectric:4.11.1'
+    testImplementation 'androidx.work:work-testing:2.9.1'
+    testImplementation 'androidx.test:core:1.5.0'
 }
 
 apply from: './upload_maven.gradle'

--- a/crashreporter/docs/breadpad.md
+++ b/crashreporter/docs/breadpad.md
@@ -1,0 +1,7 @@
+## Notes
+
+### Fetch the source and build the tools
+https://github.com/google/breakpad
+
+### Check the dump file with tools
+https://github.com/AndroidAdvanceWithGeektime/Chapter01

--- a/crashreporter/docs/upload.md
+++ b/crashreporter/docs/upload.md
@@ -1,0 +1,68 @@
+# Crash report upload
+
+CrashReporter can ship the crash reports it captures — both JVM stack traces
+(`*_crash.txt` / `*_exception.txt`) and native Breakpad minidumps
+(`core_dump/*.dmp`) — to a backend of your choice, and tracks the upload state of
+each report locally so nothing is sent twice and failures are retried.
+
+Uploading is **opt-in and disabled by default**: behaviour is unchanged until you
+register an uploader and enable it.
+
+## How it works
+
+- **You** provide the transport by implementing `CrashReportUploader`. The library
+  stays backend-agnostic and declares no `INTERNET` permission — your app declares
+  whatever its uploader needs.
+- **The library** owns discovery, state, and retry. On each upload pass it scans the
+  crash-report directory, reconciles it with a small local Room database
+  (`crashreporter_uploads.db`, in internal storage), and drains everything still
+  `PENDING`/`FAILED` through your uploader on a WorkManager background thread.
+- State per report: `PENDING → UPLOADING → UPLOADED`, or `FAILED` (retried with
+  exponential backoff until `maxUploadAttempts`, default 5).
+
+Reports are **not** uploaded on the crashing thread. A fatal crash is handled on a
+dying process, and native minidumps are written entirely in C++ — so uploads happen
+on the next launch's background pass (or immediately via `uploadPendingReports()`
+when the app is already running). Register your uploader early and unconditionally.
+
+## Usage
+
+```java
+public class MyApp extends Application {
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        // Register your transport. Called off the main thread; blocking IO is fine.
+        // Return true only when the backend has durably accepted the report.
+        CrashReporter.setUploader((report, type) -> {
+            return MyBackend.upload(report, type.name()); // your HTTP/S3/etc. call
+        });
+
+        CrashReporter.setUploadEnabled(true);
+    }
+}
+```
+
+Kotlin:
+
+```kotlin
+CrashReporter.setUploader { report, type -> myBackend.upload(report, type) }
+CrashReporter.setUploadEnabled(true)
+```
+
+Because uploads need the network, make sure your app declares
+`<uses-permission android:name="android.permission.INTERNET" />`.
+
+## API (`CrashReporter`)
+
+| Method | Purpose |
+|---|---|
+| `setUploader(CrashReportUploader)` | Register (or clear with `null`) the transport strategy. |
+| `setUploadEnabled(boolean)` | Master switch. Default `false`. Enabling with an uploader schedules a pass. |
+| `setDeleteAfterUpload(boolean)` | Delete a report file after a successful upload. Default `true`. |
+| `setMaxUploadAttempts(int)` | Attempts before a report is left permanently `FAILED`. Default `5`. |
+| `uploadPendingReports()` | Force an upload pass now (subject to network availability). |
+
+`CrashReportUploader.upload(File report, ReportType type)` returns `true` on durable
+success; returning `false` or throwing schedules a retry.

--- a/crashreporter/src/main/java/com/balsikandar/crashreporter/CrashReporter.java
+++ b/crashreporter/src/main/java/com/balsikandar/crashreporter/CrashReporter.java
@@ -4,6 +4,8 @@ import android.content.Context;
 import android.content.Intent;
 
 import com.balsikandar.crashreporter.ui.CrashReporterActivity;
+import com.balsikandar.crashreporter.upload.CrashReportUploader;
+import com.balsikandar.crashreporter.upload.CrashUploadManager;
 import com.balsikandar.crashreporter.utils.CrashReporterNotInitializedException;
 import com.balsikandar.crashreporter.utils.CrashReporterExceptionHandler;
 import com.balsikandar.crashreporter.utils.CrashUtil;
@@ -33,21 +35,9 @@ public class CrashReporter {
     }
 
     public static void initialize(Context context) {
-        System.out.println(">>><<< init CrashReporter");
-
         applicationContext = context;
         setUpExceptionHandler();
         initNative(context);
-    }
-
-    private static void initNative(Context context) {
-        String fileDir = crashReportPath == null ? CrashUtil.getDefaultPath(context) : crashReportPath;
-        File coreFolder = new File(new File(fileDir), "core_dump");
-        if (!coreFolder.exists())
-            coreFolder.mkdir();
-
-        System.out.println(">>> core dump path : " + coreFolder.getAbsolutePath());
-        CrashReporter.initBreakpad(coreFolder.getAbsolutePath());
     }
 
     public static void initialize(Context context, String crashReportSavePath) {
@@ -55,6 +45,24 @@ public class CrashReporter {
         crashReportPath = crashReportSavePath;
         setUpExceptionHandler();
         initNative(context);
+    }
+
+    private static void initNative(Context context) {
+        String fileDir = resolveCrashReportRoot(context);
+        File coreFolder = new File(new File(fileDir), "core_dump");
+        if (!coreFolder.exists())
+            coreFolder.mkdir();
+
+        CrashReporter.initBreakpad(coreFolder.getAbsolutePath());
+
+        // Set up (deferred, opt-in) upload state tracking for both text reports and
+        // native minidumps living under this root. Uploading stays disabled until the
+        // host app registers an uploader and enables it.
+        CrashUploadManager.setup(context, fileDir);
+    }
+
+    private static String resolveCrashReportRoot(Context context) {
+        return crashReportPath == null ? CrashUtil.getDefaultPath(context) : crashReportPath;
     }
 
     private static void setUpExceptionHandler() {
@@ -93,6 +101,41 @@ public class CrashReporter {
 
     public static void disableNotification() {
         isNotificationEnabled = false;
+    }
+
+    //Upload APIs
+
+    /**
+     * Register the strategy that ships crash reports to your backend. The library handles
+     * discovery, state tracking and retry; your implementation only performs the transfer.
+     * Register early (e.g. in {@code Application.onCreate}) since the process may be
+     * recreated between a crash and its upload. Pass {@code null} to clear.
+     */
+    public static void setUploader(CrashReportUploader uploader) {
+        CrashUploadManager.setUploader(uploader);
+    }
+
+    /**
+     * Enable/disable uploading. Disabled by default; enabling with an uploader registered
+     * schedules a background upload pass (subject to network availability).
+     */
+    public static void setUploadEnabled(boolean enabled) {
+        CrashUploadManager.setUploadEnabled(enabled);
+    }
+
+    /** Whether to delete a report file after it uploads successfully. Defaults to {@code true}. */
+    public static void setDeleteAfterUpload(boolean delete) {
+        CrashUploadManager.setDeleteAfterUpload(delete);
+    }
+
+    /** Max upload attempts before a report is left permanently failed. Defaults to 5. */
+    public static void setMaxUploadAttempts(int maxAttempts) {
+        CrashUploadManager.setMaxAttempts(maxAttempts);
+    }
+
+    /** Trigger an upload pass immediately (subject to the network constraint). */
+    public static void uploadPendingReports() {
+        CrashUploadManager.uploadNow();
     }
 
 }

--- a/crashreporter/src/main/java/com/balsikandar/crashreporter/upload/CrashReportUploader.kt
+++ b/crashreporter/src/main/java/com/balsikandar/crashreporter/upload/CrashReportUploader.kt
@@ -1,0 +1,31 @@
+package com.balsikandar.crashreporter.upload
+
+import java.io.File
+
+/**
+ * Consumer-supplied strategy for shipping a single crash report file to a backend.
+ *
+ * CrashReporter owns discovery, state persistence and retry scheduling; the host app
+ * owns *where* the report goes. Register an implementation with
+ * [com.balsikandar.crashreporter.CrashReporter.setUploader].
+ *
+ * Implementations:
+ *  - are invoked on a WorkManager background thread (never on the crashing thread), so
+ *    blocking network calls are fine here;
+ *  - must return `true` only when the report has been durably accepted by the backend;
+ *  - may throw — a thrown exception is treated exactly like returning `false` (the report
+ *    is retried later with backoff until the attempt limit is reached).
+ *
+ * Because the app process can be recreated between a crash and the upload, register the
+ * uploader early and unconditionally (e.g. in `Application.onCreate`), not only right after
+ * a crash.
+ */
+fun interface CrashReportUploader {
+    /**
+     * @param report the report file on disk (a `.txt` stack trace or a `.dmp` minidump).
+     * @param type   which kind of report [report] is.
+     * @return `true` if the backend durably accepted the report; `false` to retry later.
+     */
+    @Throws(Exception::class)
+    fun upload(report: File, type: ReportType): Boolean
+}

--- a/crashreporter/src/main/java/com/balsikandar/crashreporter/upload/CrashUploadManager.kt
+++ b/crashreporter/src/main/java/com/balsikandar/crashreporter/upload/CrashUploadManager.kt
@@ -1,0 +1,110 @@
+package com.balsikandar.crashreporter.upload
+
+import android.content.Context
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequest
+import androidx.work.WorkManager
+import com.balsikandar.crashreporter.upload.internal.CrashUploadWorker
+import java.util.concurrent.TimeUnit
+
+/**
+ * Coordinates crash-report upload: holds the consumer configuration and schedules the
+ * background [CrashUploadWorker].
+ *
+ * Wiring:
+ *  - [setup] is called once by `CrashReporter.initialize(...)` at app startup (via the
+ *    auto-init ContentProvider), giving us the app context and the crash-report directory.
+ *  - The host app then opts in with [setUploader] + [setUploadEnabled] (e.g. in
+ *    `Application.onCreate`). Enabling with an uploader present schedules an upload pass.
+ *
+ * The registered uploader is held only in memory: after a process restart the host must
+ * register it again before reports can be sent, hence the worker retries when none is set.
+ */
+object CrashUploadManager {
+
+    private const val UNIQUE_WORK_NAME = "crashreporter_upload"
+    private const val BACKOFF_SECONDS = 30L
+
+    @Volatile
+    private var appContext: Context? = null
+
+    @Volatile
+    private var uploadEnabled: Boolean = false
+
+    @Volatile
+    internal var crashReportRootPath: String? = null
+        private set
+
+    @Volatile
+    internal var uploader: CrashReportUploader? = null
+        private set
+
+    @Volatile
+    internal var deleteAfterUpload: Boolean = true
+        private set
+
+    @Volatile
+    internal var maxAttempts: Int = 5
+        private set
+
+    /** Called by the library at initialize time. Not part of the consumer-facing API. */
+    @JvmStatic
+    fun setup(context: Context, crashReportRootPath: String) {
+        this.appContext = context.applicationContext
+        this.crashReportRootPath = crashReportRootPath
+        maybeEnqueue()
+    }
+
+    /** Register (or clear with `null`) the strategy that ships reports to a backend. */
+    @JvmStatic
+    fun setUploader(uploader: CrashReportUploader?) {
+        this.uploader = uploader
+        maybeEnqueue()
+    }
+
+    /** Master switch for uploading. Disabled by default so behaviour is unchanged until opted in. */
+    @JvmStatic
+    fun setUploadEnabled(enabled: Boolean) {
+        this.uploadEnabled = enabled
+        if (enabled) maybeEnqueue()
+    }
+
+    /** Delete a report file once it has been uploaded successfully. Defaults to `true`. */
+    @JvmStatic
+    fun setDeleteAfterUpload(delete: Boolean) {
+        this.deleteAfterUpload = delete
+    }
+
+    /** Max upload attempts before a report is left as permanently `FAILED`. Defaults to 5. */
+    @JvmStatic
+    fun setMaxAttempts(max: Int) {
+        this.maxAttempts = max.coerceAtLeast(1)
+    }
+
+    /** Force an upload pass now (subject to the network constraint), replacing any pending run. */
+    @JvmStatic
+    fun uploadNow() {
+        enqueue(ExistingWorkPolicy.REPLACE)
+    }
+
+    private fun maybeEnqueue() {
+        if (uploadEnabled && uploader != null && appContext != null && crashReportRootPath != null) {
+            enqueue(ExistingWorkPolicy.KEEP)
+        }
+    }
+
+    private fun enqueue(policy: ExistingWorkPolicy) {
+        val context = appContext ?: return
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
+        val request = OneTimeWorkRequest.Builder(CrashUploadWorker::class.java)
+            .setConstraints(constraints)
+            .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, BACKOFF_SECONDS, TimeUnit.SECONDS)
+            .build()
+        WorkManager.getInstance(context).enqueueUniqueWork(UNIQUE_WORK_NAME, policy, request)
+    }
+}

--- a/crashreporter/src/main/java/com/balsikandar/crashreporter/upload/ReportType.kt
+++ b/crashreporter/src/main/java/com/balsikandar/crashreporter/upload/ReportType.kt
@@ -1,0 +1,14 @@
+package com.balsikandar.crashreporter.upload
+
+/**
+ * The kind of crash report a [CrashReportUploader] is asked to upload.
+ *
+ * - [CRASH]     : a fatal JVM crash stack-trace (`*_crash.txt`).
+ * - [EXCEPTION] : a manually logged non-fatal exception (`*_exception.txt`).
+ * - [MINIDUMP]  : a native Breakpad minidump (`*.dmp` under `core_dump/`).
+ */
+enum class ReportType {
+    CRASH,
+    EXCEPTION,
+    MINIDUMP
+}

--- a/crashreporter/src/main/java/com/balsikandar/crashreporter/upload/internal/Converters.kt
+++ b/crashreporter/src/main/java/com/balsikandar/crashreporter/upload/internal/Converters.kt
@@ -1,0 +1,20 @@
+package com.balsikandar.crashreporter.upload.internal
+
+import androidx.room.TypeConverter
+import com.balsikandar.crashreporter.upload.ReportType
+
+/** Room converters for the enums stored on [CrashReportEntity]. */
+internal class Converters {
+
+    @TypeConverter
+    fun reportTypeToString(type: ReportType): String = type.name
+
+    @TypeConverter
+    fun stringToReportType(value: String): ReportType = ReportType.valueOf(value)
+
+    @TypeConverter
+    fun uploadStatusToString(status: UploadStatus): String = status.name
+
+    @TypeConverter
+    fun stringToUploadStatus(value: String): UploadStatus = UploadStatus.valueOf(value)
+}

--- a/crashreporter/src/main/java/com/balsikandar/crashreporter/upload/internal/CrashReportDao.kt
+++ b/crashreporter/src/main/java/com/balsikandar/crashreporter/upload/internal/CrashReportDao.kt
@@ -1,0 +1,54 @@
+package com.balsikandar.crashreporter.upload.internal
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+/**
+ * Blocking DAO. All methods are invoked from a WorkManager background thread
+ * ([CrashUploadWorker]) — never from the main thread or the crashing thread — so
+ * synchronous queries are safe.
+ */
+@Dao
+internal interface CrashReportDao {
+
+    /**
+     * Insert newly discovered reports. [OnConflictStrategy.IGNORE] keeps the existing row
+     * (and therefore its status/attempt history) for files already tracked.
+     */
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    fun insertIgnore(reports: List<CrashReportEntity>)
+
+    @Query("SELECT filePath FROM crash_reports")
+    fun getAllPaths(): List<String>
+
+    /** Reports still worth attempting: never-sent or previously failed but under the limit. */
+    @Query(
+        "SELECT * FROM crash_reports " +
+            "WHERE status IN ('PENDING', 'FAILED') AND attemptCount < :maxAttempts " +
+            "ORDER BY createdAt ASC"
+    )
+    fun getUploadable(maxAttempts: Int): List<CrashReportEntity>
+
+    @Query("SELECT COUNT(*) FROM crash_reports WHERE status IN ('PENDING', 'FAILED') AND attemptCount < :maxAttempts")
+    fun countUploadable(maxAttempts: Int): Int
+
+    @Query("UPDATE crash_reports SET status = :status WHERE filePath = :filePath")
+    fun updateStatus(filePath: String, status: UploadStatus)
+
+    @Query(
+        "UPDATE crash_reports SET status = :status, attemptCount = :attemptCount, " +
+            "lastAttemptAt = :lastAttemptAt, lastError = :lastError WHERE filePath = :filePath"
+    )
+    fun updateAttempt(
+        filePath: String,
+        status: UploadStatus,
+        attemptCount: Int,
+        lastAttemptAt: Long,
+        lastError: String?
+    )
+
+    @Query("DELETE FROM crash_reports WHERE filePath = :filePath")
+    fun deleteByPath(filePath: String)
+}

--- a/crashreporter/src/main/java/com/balsikandar/crashreporter/upload/internal/CrashReportDatabase.kt
+++ b/crashreporter/src/main/java/com/balsikandar/crashreporter/upload/internal/CrashReportDatabase.kt
@@ -1,0 +1,29 @@
+package com.balsikandar.crashreporter.upload.internal
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+
+@Database(entities = [CrashReportEntity::class], version = 1, exportSchema = false)
+@TypeConverters(Converters::class)
+internal abstract class CrashReportDatabase : RoomDatabase() {
+
+    abstract fun crashReportDao(): CrashReportDao
+
+    companion object {
+        @Volatile
+        private var instance: CrashReportDatabase? = null
+
+        /** Lives in internal storage, separate from the (external) crash-report files. */
+        fun getInstance(context: Context): CrashReportDatabase =
+            instance ?: synchronized(this) {
+                instance ?: Room.databaseBuilder(
+                    context.applicationContext,
+                    CrashReportDatabase::class.java,
+                    "crashreporter_uploads.db"
+                ).build().also { instance = it }
+            }
+    }
+}

--- a/crashreporter/src/main/java/com/balsikandar/crashreporter/upload/internal/CrashReportEntity.kt
+++ b/crashreporter/src/main/java/com/balsikandar/crashreporter/upload/internal/CrashReportEntity.kt
@@ -1,0 +1,24 @@
+package com.balsikandar.crashreporter.upload.internal
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.balsikandar.crashreporter.upload.ReportType
+
+/**
+ * Local record tracking the upload state of one crash report file.
+ *
+ * The absolute file path is the primary key: the file itself is the source of truth for
+ * "does this report exist", and the DB row is the source of truth for "has it been sent".
+ * Rows are (re)populated by [CrashReportScanner] on each upload run, never on the crashing
+ * thread.
+ */
+@Entity(tableName = "crash_reports")
+internal data class CrashReportEntity(
+    @PrimaryKey val filePath: String,
+    val type: ReportType,
+    val status: UploadStatus = UploadStatus.PENDING,
+    val attemptCount: Int = 0,
+    val createdAt: Long,
+    val lastAttemptAt: Long = 0L,
+    val lastError: String? = null
+)

--- a/crashreporter/src/main/java/com/balsikandar/crashreporter/upload/internal/CrashReportScanner.kt
+++ b/crashreporter/src/main/java/com/balsikandar/crashreporter/upload/internal/CrashReportScanner.kt
@@ -1,0 +1,72 @@
+package com.balsikandar.crashreporter.upload.internal
+
+import android.util.Log
+import com.balsikandar.crashreporter.upload.ReportType
+import com.balsikandar.crashreporter.utils.Constants
+import java.io.File
+
+/**
+ * Reconciles the crash-report files on disk with the local state store.
+ *
+ * This is the only path that discovers reports for upload. It runs inside
+ * [CrashUploadWorker] on a background thread — deliberately NOT at crash time, because:
+ *  - a fatal JVM crash is handled on the dying thread, where DB work is unsafe;
+ *  - native minidumps are written entirely in C++, so the JVM never observes them until
+ *    a later launch anyway.
+ *
+ * New files become [UploadStatus.PENDING] rows; rows whose backing file is gone are pruned.
+ */
+internal object CrashReportScanner {
+
+    private const val TAG = "CrashReportScanner"
+    private const val CORE_DUMP_DIR = "core_dump"
+    private const val MINIDUMP_EXTENSION = ".dmp"
+
+    fun reconcile(dao: CrashReportDao, crashReportRootPath: String) {
+        val root = File(crashReportRootPath)
+        val discovered = mutableListOf<CrashReportEntity>()
+
+        // Text reports live directly under the root: *_crash.txt and *_exception.txt
+        root.listFiles()?.forEach { file ->
+            if (file.isFile && file.name.endsWith(Constants.FILE_EXTENSION)) {
+                classifyTextReport(file.name)?.let { type ->
+                    discovered += newEntity(file, type)
+                }
+            }
+        }
+
+        // Native minidumps live under core_dump/*.dmp
+        File(root, CORE_DUMP_DIR).listFiles()?.forEach { file ->
+            if (file.isFile && file.name.endsWith(MINIDUMP_EXTENSION)) {
+                discovered += newEntity(file, ReportType.MINIDUMP)
+            }
+        }
+
+        if (discovered.isNotEmpty()) {
+            dao.insertIgnore(discovered)
+        }
+
+        // Prune rows whose backing file was deleted (e.g. after a successful upload+cleanup,
+        // or a manual delete from the viewer UI).
+        val onDisk = discovered.mapTo(HashSet()) { it.filePath }
+        dao.getAllPaths().forEach { path ->
+            if (path !in onDisk && !File(path).exists()) {
+                dao.deleteByPath(path)
+            }
+        }
+
+        Log.d(TAG, "reconciled ${discovered.size} report file(s) under $crashReportRootPath")
+    }
+
+    private fun classifyTextReport(name: String): ReportType? = when {
+        name.contains(Constants.CRASH_SUFFIX) -> ReportType.CRASH
+        name.contains(Constants.EXCEPTION_SUFFIX) -> ReportType.EXCEPTION
+        else -> null
+    }
+
+    private fun newEntity(file: File, type: ReportType) = CrashReportEntity(
+        filePath = file.absolutePath,
+        type = type,
+        createdAt = file.lastModified()
+    )
+}

--- a/crashreporter/src/main/java/com/balsikandar/crashreporter/upload/internal/CrashUploadWorker.kt
+++ b/crashreporter/src/main/java/com/balsikandar/crashreporter/upload/internal/CrashUploadWorker.kt
@@ -1,0 +1,83 @@
+package com.balsikandar.crashreporter.upload.internal
+
+import android.content.Context
+import android.util.Log
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+import com.balsikandar.crashreporter.upload.CrashUploadManager
+import java.io.File
+
+/**
+ * Drains pending crash reports through the registered
+ * [com.balsikandar.crashreporter.upload.CrashReportUploader].
+ *
+ * Runs on WorkManager's background executor (blocking [Worker.doWork]), so all DB and
+ * network work here is off the main/crashing thread. Each run first reconciles the
+ * on-disk files with the state store, then attempts every uploadable report once.
+ */
+internal class CrashUploadWorker(
+    context: Context,
+    params: WorkerParameters
+) : Worker(context, params) {
+
+    override fun doWork(): Result {
+        val root = CrashUploadManager.crashReportRootPath
+        if (root == null) {
+            Log.w(TAG, "no crash-report path configured; nothing to upload")
+            return Result.success()
+        }
+
+        val uploader = CrashUploadManager.uploader
+        if (uploader == null) {
+            // Process may have been recreated before the host re-registered its uploader.
+            // Retry with backoff so we don't drop reports.
+            Log.d(TAG, "no uploader registered yet; will retry")
+            return Result.retry()
+        }
+
+        val dao = CrashReportDatabase.getInstance(applicationContext).crashReportDao()
+        CrashReportScanner.reconcile(dao, root)
+
+        val maxAttempts = CrashUploadManager.maxAttempts
+        val deleteAfterUpload = CrashUploadManager.deleteAfterUpload
+        var hadFailure = false
+
+        for (entity in dao.getUploadable(maxAttempts)) {
+            val file = File(entity.filePath)
+            if (!file.exists()) {
+                dao.deleteByPath(entity.filePath)
+                continue
+            }
+
+            dao.updateStatus(entity.filePath, UploadStatus.UPLOADING)
+            val now = System.currentTimeMillis()
+            val nextAttempt = entity.attemptCount + 1
+
+            try {
+                if (uploader.upload(file, entity.type)) {
+                    dao.updateAttempt(entity.filePath, UploadStatus.UPLOADED, nextAttempt, now, null)
+                    if (deleteAfterUpload) {
+                        file.delete()
+                        dao.deleteByPath(entity.filePath)
+                    }
+                    Log.d(TAG, "uploaded ${entity.type} report: ${file.name}")
+                } else {
+                    hadFailure = true
+                    dao.updateAttempt(entity.filePath, UploadStatus.FAILED, nextAttempt, now, "uploader returned false")
+                }
+            } catch (e: Exception) {
+                hadFailure = true
+                dao.updateAttempt(entity.filePath, UploadStatus.FAILED, nextAttempt, now, e.message)
+                Log.w(TAG, "upload failed for ${file.name}", e)
+            }
+        }
+
+        // Ask WorkManager to retry (with backoff) only if something failed and is still
+        // under the attempt limit; otherwise we're done for this run.
+        return if (hadFailure && dao.countUploadable(maxAttempts) > 0) Result.retry() else Result.success()
+    }
+
+    companion object {
+        private const val TAG = "CrashUploadWorker"
+    }
+}

--- a/crashreporter/src/main/java/com/balsikandar/crashreporter/upload/internal/UploadStatus.kt
+++ b/crashreporter/src/main/java/com/balsikandar/crashreporter/upload/internal/UploadStatus.kt
@@ -1,0 +1,15 @@
+package com.balsikandar.crashreporter.upload.internal
+
+/**
+ * Upload lifecycle of a single crash report, persisted in the local [CrashReportEntity].
+ *
+ * PENDING → UPLOADING → UPLOADED           (happy path)
+ *              ↓
+ *            FAILED → (retried while attemptCount < max) → UPLOADED
+ */
+internal enum class UploadStatus {
+    PENDING,
+    UPLOADING,
+    UPLOADED,
+    FAILED
+}

--- a/crashreporter/src/test/java/com/balsikandar/crashreporter/upload/internal/CrashReportDaoTest.kt
+++ b/crashreporter/src/test/java/com/balsikandar/crashreporter/upload/internal/CrashReportDaoTest.kt
@@ -1,0 +1,69 @@
+package com.balsikandar.crashreporter.upload.internal
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.balsikandar.crashreporter.upload.ReportType
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class CrashReportDaoTest {
+
+    private lateinit var db: CrashReportDatabase
+    private lateinit var dao: CrashReportDao
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            CrashReportDatabase::class.java
+        ).allowMainThreadQueries().build()
+        dao = db.crashReportDao()
+    }
+
+    @After
+    fun tearDown() = db.close()
+
+    private fun entity(path: String, type: ReportType = ReportType.CRASH) =
+        CrashReportEntity(filePath = path, type = type, createdAt = 1L)
+
+    @Test
+    fun givenNewReports_whenInsertIgnore_thenAllTracked() {
+        dao.insertIgnore(listOf(entity("/a_crash.txt"), entity("/b.dmp", ReportType.MINIDUMP)))
+
+        assertEquals(2, dao.getUploadable(5).size)
+    }
+
+    @Test
+    fun givenExistingRow_whenInsertIgnoreSamePath_thenStatusPreserved() {
+        dao.insertIgnore(listOf(entity("/a_crash.txt")))
+        dao.updateStatus("/a_crash.txt", UploadStatus.UPLOADED)
+
+        // Re-discovering the same file must not reset it back to PENDING.
+        dao.insertIgnore(listOf(entity("/a_crash.txt")))
+
+        assertTrue(dao.getUploadable(5).isEmpty())
+    }
+
+    @Test
+    fun givenAttemptsAtLimit_whenGetUploadable_thenExcluded() {
+        dao.insertIgnore(listOf(entity("/a_crash.txt")))
+        dao.updateAttempt("/a_crash.txt", UploadStatus.FAILED, 5, 10L, "boom")
+
+        assertTrue(dao.getUploadable(5).isEmpty())
+        assertEquals(0, dao.countUploadable(5))
+    }
+
+    @Test
+    fun givenFailedUnderLimit_whenGetUploadable_thenRetryable() {
+        dao.insertIgnore(listOf(entity("/a_crash.txt")))
+        dao.updateAttempt("/a_crash.txt", UploadStatus.FAILED, 2, 10L, "boom")
+
+        assertEquals(1, dao.getUploadable(5).size)
+    }
+}

--- a/crashreporter/src/test/java/com/balsikandar/crashreporter/upload/internal/CrashReportScannerTest.kt
+++ b/crashreporter/src/test/java/com/balsikandar/crashreporter/upload/internal/CrashReportScannerTest.kt
@@ -1,0 +1,83 @@
+package com.balsikandar.crashreporter.upload.internal
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.balsikandar.crashreporter.upload.ReportType
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+class CrashReportScannerTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var db: CrashReportDatabase
+    private lateinit var dao: CrashReportDao
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            CrashReportDatabase::class.java
+        ).allowMainThreadQueries().build()
+        dao = db.crashReportDao()
+    }
+
+    @After
+    fun tearDown() = db.close()
+
+    private fun write(dir: File, name: String): File =
+        File(dir, name).apply { parentFile?.mkdirs(); writeText("stack") }
+
+    @Test
+    fun givenMixedFiles_whenReconcile_thenClassifiedByLocationAndSuffix() {
+        val root = tempFolder.root
+        write(root, "2026-07-14 10-00-00_crash.txt")
+        write(root, "2026-07-14 10-01-00_exception.txt")
+        write(root, "notes.log") // ignored: wrong extension
+        val coreDump = File(root, "core_dump").apply { mkdirs() }
+        write(coreDump, "abc123.dmp")
+
+        CrashReportScanner.reconcile(dao, root.absolutePath)
+
+        val byType = dao.getUploadable(5).groupBy { it.type }
+        assertEquals(1, byType[ReportType.CRASH]?.size)
+        assertEquals(1, byType[ReportType.EXCEPTION]?.size)
+        assertEquals(1, byType[ReportType.MINIDUMP]?.size)
+    }
+
+    @Test
+    fun givenTrackedFileDeleted_whenReconcile_thenRowPruned() {
+        val root = tempFolder.root
+        val crash = write(root, "2026-07-14 10-00-00_crash.txt")
+        CrashReportScanner.reconcile(dao, root.absolutePath)
+        assertEquals(1, dao.getAllPaths().size)
+
+        assertTrue(crash.delete())
+        CrashReportScanner.reconcile(dao, root.absolutePath)
+
+        assertTrue(dao.getAllPaths().isEmpty())
+    }
+
+    @Test
+    fun givenAlreadyUploaded_whenReconcile_thenNotResurrected() {
+        val root = tempFolder.root
+        val crash = write(root, "2026-07-14 10-00-00_crash.txt")
+        CrashReportScanner.reconcile(dao, root.absolutePath)
+        dao.updateStatus(crash.absolutePath, UploadStatus.UPLOADED)
+
+        CrashReportScanner.reconcile(dao, root.absolutePath)
+
+        assertFalse(dao.getUploadable(5).any { it.filePath == crash.absolutePath })
+    }
+}

--- a/crashreporter/src/test/java/com/balsikandar/crashreporter/upload/internal/CrashUploadWorkerTest.kt
+++ b/crashreporter/src/test/java/com/balsikandar/crashreporter/upload/internal/CrashUploadWorkerTest.kt
@@ -1,0 +1,104 @@
+package com.balsikandar.crashreporter.upload.internal
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.ListenableWorker
+import androidx.work.testing.TestListenableWorkerBuilder
+import com.balsikandar.crashreporter.upload.CrashReportUploader
+import com.balsikandar.crashreporter.upload.CrashUploadManager
+import com.balsikandar.crashreporter.upload.ReportType
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+import java.util.concurrent.Executors
+
+@RunWith(RobolectricTestRunner::class)
+class CrashUploadWorkerTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private val executor = Executors.newSingleThreadExecutor()
+    private lateinit var context: Context
+    private lateinit var root: File
+
+    /** Room forbids main-thread queries; the WorkManager worker (and our assertions) run off it. */
+    private fun <T> onBackground(block: () -> T): T = executor.submit(block).get()
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        root = tempFolder.root
+        File(root, "2026-07-14 10-00-00_crash.txt").writeText("stack")
+        CrashUploadManager.setup(context, root.absolutePath)
+        CrashUploadManager.setDeleteAfterUpload(true)
+        onBackground { CrashReportDatabase.getInstance(context).clearAllTables() }
+    }
+
+    @After
+    fun tearDown() {
+        CrashUploadManager.setUploader(null)
+        executor.shutdown()
+    }
+
+    private fun runWorker(): ListenableWorker.Result {
+        // doWork() is synchronous; run it off the main thread so Room queries are allowed.
+        val worker = TestListenableWorkerBuilder<CrashUploadWorker>(context).build()
+        return onBackground { worker.doWork() }
+    }
+
+    private fun crashFile() = File(root, "2026-07-14 10-00-00_crash.txt")
+
+    @Test
+    fun givenNoUploader_whenRun_thenRetry() {
+        CrashUploadManager.setUploader(null)
+
+        assertEquals(ListenableWorker.Result.retry(), runWorker())
+    }
+
+    @Test
+    fun givenUploaderSucceeds_whenRun_thenSuccessAndFileDeleted() {
+        val uploaded = mutableListOf<ReportType>()
+        CrashUploadManager.setUploader(CrashReportUploader { _, type -> uploaded += type; true })
+
+        val result = runWorker()
+
+        assertEquals(ListenableWorker.Result.success(), result)
+        assertEquals(listOf(ReportType.CRASH), uploaded)
+        assertFalse(crashFile().exists())
+    }
+
+    @Test
+    fun givenUploaderReturnsFalse_whenRun_thenRetryAndFileKept() {
+        CrashUploadManager.setUploader(CrashReportUploader { _, _ -> false })
+
+        val result = runWorker()
+
+        assertEquals(ListenableWorker.Result.retry(), result)
+        assertTrue(crashFile().exists())
+
+        val failed = onBackground {
+            CrashReportDatabase.getInstance(context).crashReportDao().getUploadable(5).single()
+        }
+        assertEquals(UploadStatus.FAILED, failed.status)
+        assertEquals(1, failed.attemptCount)
+    }
+
+    @Test
+    fun givenUploaderThrows_whenRun_thenRetryAndFileKept() {
+        CrashUploadManager.setUploader(CrashReportUploader { _, _ -> throw RuntimeException("network down") })
+
+        val result = runWorker()
+
+        assertEquals(ListenableWorker.Result.retry(), result)
+        assertTrue(crashFile().exists())
+    }
+}

--- a/crashreporter/src/test/resources/robolectric.properties
+++ b/crashreporter/src/test/resources/robolectric.properties
@@ -1,0 +1,3 @@
+# Robolectric 4.11.x has no sandbox for Android SDK 35 (the project's compileSdk),
+# so pin unit tests to a supported API level.
+sdk=33


### PR DESCRIPTION
## Summary

Adds an **opt-in** mechanism to upload local crash reports to a backend and track the upload state of each report. Previously the library only captured reports (JVM `*_crash.txt` / `*_exception.txt` and native Breakpad `core_dump/*.dmp`) and surfaced them on-device — there was no egress path and no state beyond the filename suffix.

The library stays **backend-agnostic**: the host app supplies the transport via `CrashReportUploader`; the library owns discovery, state, and retry. No `INTERNET` permission is added to the library manifest.

## What's included

- **`CrashReportUploader`** — consumer-implemented `upload(File, ReportType): Boolean`.
- **Room state store** — per-report status (`PENDING → UPLOADING → UPLOADED` / `FAILED`), attempt count, timestamps, last error (`crashreporter_uploads.db`, internal storage).
- **`CrashReportScanner`** — reconciles both report locations with the store on each run; prunes rows for deleted files.
- **`CrashUploadWorker`** (WorkManager) — drains uploadable reports **off the crashing thread**, with a `CONNECTED` constraint and exponential-backoff retry up to `maxUploadAttempts` (default 5).
- **Public API on `CrashReporter`**: `setUploader`, `setUploadEnabled` (**off by default**), `setDeleteAfterUpload`, `setMaxUploadAttempts`, `uploadPendingReports`.
- Removed leftover `System.out.println(">>>…")` debug lines from `initialize`/`initNative`.
- `docs/upload.md`.

## Design notes

- **Deferred, not instant-on-crash.** A fatal crash is handled on a dying thread and native minidumps are written entirely in C++, so uploads run on the next launch's background pass (or immediately via `uploadPendingReports()` while the app is running).
- The uploader is held in memory, so the worker retries when none is registered yet — register it early (e.g. `Application.onCreate`).

## Testing

`./gradlew :crashreporter:testDebugUnitTest` → **passing** (11 new Robolectric tests across DAO, scanner, worker; success / false / throw / no-uploader paths). Robolectric pinned to SDK 33 since 4.11.1 has no sandbox for compileSdk 35.

⚠️ The full NDK `assembleDebug` was not run in this environment — worth a full assemble before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in crash report uploading to configurable backends.
  * Added background uploads with network requirements, retry handling, and configurable attempt limits.
  * Added options to trigger pending uploads and delete reports after successful delivery.
  * Added support for crash reports, exceptions, and native minidumps.

* **Documentation**
  * Added guides for building diagnostic tools and configuring crash report uploads.

* **Tests**
  * Expanded coverage for report tracking, scanning, uploading, retries, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->